### PR TITLE
Add default case for switch statements

### DIFF
--- a/core/src/main/java/roart/util/MyLockFactory.java
+++ b/core/src/main/java/roart/util/MyLockFactory.java
@@ -18,6 +18,11 @@ public class MyLockFactory {
         case Constants.ZOOKEEPER:
             return new MyZookeeperLock();
             */
+        //missing default case
+        default:
+            // add default case
+            break;
+
         }
         return new MyDummyLock();
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html