### PR TITLE
Add default case for switch statements

### DIFF
--- a/core/src/main/java/roart/filesystem/FileSystemFactory.java
+++ b/core/src/main/java/roart/filesystem/FileSystemFactory.java
@@ -13,6 +13,11 @@ public class FileSystemFactory {
             return new HDFSAccess();
         case SWIFT:
             return new SwiftAccess();
+        //missing default case
+        default:
+            // add default case
+            break;
+        
         }
         return null;
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html